### PR TITLE
Add basic character creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ python3 -m http.server
 
 and then visit `http://localhost:8000/app.html`.
 
+## Character generator
+
+A simpler character generator is available in `creator.html`. It loads occupations from `occupations.json`, lets you roll characteristics and exports the result to a PDF file using [jsPDF](https://github.com/parallax/jsPDF).
+
+Open `creator.html` in your browser or with the local server above.
+
 ## Planned features
 
 - Guided steps for creating a character (rolling characteristics, computing derived attributes and selecting an occupation).

--- a/characterCreator.js
+++ b/characterCreator.js
@@ -1,0 +1,144 @@
+export class CharacterCreator {
+    constructor() {
+        this.character = {
+            stats: {
+                FUE: 0, CON: 0, TAM: 0, DES: 0, APA: 0,
+                INT: 0, POD: 0, EDU: 0, SUE: 0
+            },
+            derived: { HP: 0, SAN: 0, MP: 0 },
+            occupation: null,
+            skills: {}
+        };
+        this.occupations = [];
+    }
+
+    async init() {
+        await this.loadOccupations();
+        this.populateOccupationSelect();
+        this.renderStats();
+        document.getElementById('roll-all').addEventListener('click', () => {
+            this.rollAll();
+        });
+        document.getElementById('occupation-select').addEventListener('change', e => {
+            this.selectOccupation(e.target.value);
+        });
+        document.getElementById('export-btn').addEventListener('click', () => {
+            this.exportPDF();
+        });
+    }
+
+    async loadOccupations() {
+        const resp = await fetch('occupations.json');
+        this.occupations = await resp.json();
+    }
+
+    populateOccupationSelect() {
+        const select = document.getElementById('occupation-select');
+        select.innerHTML = '<option value="">--Selecciona--</option>';
+        this.occupations.forEach(o => {
+            const opt = document.createElement('option');
+            opt.value = o.name;
+            opt.textContent = o.name;
+            select.appendChild(opt);
+        });
+    }
+
+    renderStats() {
+        const grid = document.getElementById('stats-grid');
+        grid.innerHTML = '';
+        Object.keys(this.character.stats).forEach(key => {
+            const card = document.createElement('div');
+            card.className = 'characteristic-card';
+            const name = document.createElement('div');
+            name.className = 'char-name';
+            name.textContent = key;
+            const val = document.createElement('div');
+            val.id = `stat-${key}`;
+            val.className = 'result-display';
+            val.textContent = '-';
+            card.appendChild(name);
+            card.appendChild(val);
+            const btn = document.createElement('button');
+            btn.textContent = 'Tirar';
+            btn.className = 'dice-button';
+            btn.addEventListener('click', () => {
+                this.rollStat(key);
+            });
+            card.appendChild(btn);
+            grid.appendChild(card);
+        });
+    }
+
+    rollDice(n, s) {
+        let t = 0;
+        for (let i=0;i<n;i++) t += Math.floor(Math.random()*s)+1;
+        return t;
+    }
+
+    rollStat(stat) {
+        let value;
+        if (['TAM','INT','EDU'].includes(stat)) {
+            value = (this.rollDice(2,6)+6)*5;
+        } else {
+            value = this.rollDice(3,6)*5;
+        }
+        this.character.stats[stat] = value;
+        document.getElementById(`stat-${stat}`).textContent = value;
+        this.calculateDerived();
+        this.updateDerivedUI();
+    }
+
+    rollAll() {
+        Object.keys(this.character.stats).forEach(stat => this.rollStat(stat));
+    }
+
+    calculateDerived() {
+        const c = this.character.stats;
+        this.character.derived.SAN = c.POD;
+        this.character.derived.MP = Math.floor(c.POD/5);
+        if(c.CON && c.TAM){
+            this.character.derived.HP = Math.floor((c.CON + c.TAM)/10);
+        }
+    }
+
+    updateDerivedUI() {
+        document.getElementById('hp-field').textContent = this.character.derived.HP || '-';
+        document.getElementById('sanity-field').textContent = this.character.derived.SAN || '-';
+        document.getElementById('mp-field').textContent = this.character.derived.MP || '-';
+    }
+
+    selectOccupation(name) {
+        this.character.occupation = this.occupations.find(o => o.name === name);
+        const list = document.getElementById('skills-list');
+        list.innerHTML = '';
+        if (this.character.occupation) {
+            this.character.occupation.skills.forEach(sk => {
+                const li = document.createElement('li');
+                li.textContent = sk;
+                list.appendChild(li);
+            });
+        }
+    }
+
+    exportPDF() {
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        doc.text('Personaje de Call of Cthulhu', 10, 10);
+        let y = 20;
+        Object.entries(this.character.stats).forEach(([k,v]) => {
+            doc.text(`${k}: ${v}`, 10, y); y += 6;
+        });
+        doc.text(`PV: ${this.character.derived.HP}`, 10, y); y +=6;
+        doc.text(`Cordura: ${this.character.derived.SAN}`,10,y); y+=6;
+        doc.text(`PM: ${this.character.derived.MP}`,10,y); y+=10;
+        if(this.character.occupation){
+            doc.text(`Ocupación: ${this.character.occupation.name}`,10,y); y+=6;
+            doc.text('Habilidades:',10,y); y+=6;
+            this.character.occupation.skills.forEach(sk => { doc.text(`- ${sk}`, 12, y); y+=6; });
+        }
+        doc.save('personaje.pdf');
+    }
+}
+
+const creator = new CharacterCreator();
+creator.init();

--- a/creator.html
+++ b/creator.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Generador de Personajes - CoC7</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script type="module" src="characterCreator.js"></script>
+</head>
+<body>
+    <div class="container" style="padding:20px;">
+        <h1 style="text-align:center;margin-bottom:20px;">Generador de Personajes</h1>
+        <section>
+            <h2 class="section-title">Características</h2>
+            <div class="characteristics-grid" id="stats-grid">
+                <!-- stats will be inserted here -->
+            </div>
+            <button class="dice-button" id="roll-all">Tirar Todas</button>
+        </section>
+        <section>
+            <h2 class="section-title">Atributos Derivados</h2>
+            <div class="characteristics-grid" id="derived-grid">
+                <div class="characteristic-card"><div class="char-name">PV</div><div id="hp-field" class="result-display">-</div></div>
+                <div class="characteristic-card"><div class="char-name">Cordura</div><div id="sanity-field" class="result-display">-</div></div>
+                <div class="characteristic-card"><div class="char-name">Puntos de Magia</div><div id="mp-field" class="result-display">-</div></div>
+            </div>
+        </section>
+        <section>
+            <h2 class="section-title">Ocupación</h2>
+            <select id="occupation-select"></select>
+            <ul id="skills-list"></ul>
+        </section>
+        <button class="dice-button" id="export-btn">Exportar a PDF</button>
+    </div>
+</body>
+</html>

--- a/occupations.json
+++ b/occupations.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "Abogado",
+    "credit": "30-80",
+    "skillPoints": "EDU × 4",
+    "skills": ["Contabilidad", "Derecho", "Psicología", "Usar Bibliotecas", "Interpersonal ×2", "Otras ×2"]
+  },
+  {
+    "name": "Artista",
+    "credit": "9-50",
+    "skillPoints": "EDU × 2 + (POD/DES × 2)",
+    "skills": ["Arte/Oficio", "Encontrar", "Historia o Mundo Natural", "Otra Lengua", "Psicología", "Interpersonal", "Otras ×2"]
+  },
+  {
+    "name": "Investigador de Policía",
+    "credit": "20-50",
+    "skillPoints": "EDU × 2 + (DES/FUE × 2)",
+    "skills": ["Arte/Oficio (Actuar) o Disfraz", "Armas de Fuego", "Derecho", "Escuchar", "Psicología", "Encontrar", "Interpersonal", "Otra"]
+  },
+  {
+    "name": "Médico",
+    "credit": "30-80",
+    "skillPoints": "EDU × 4",
+    "skills": ["Ciencia (Biología)", "Ciencia (Farmacia)", "Medicina", "Otra Lengua (Latín)", "Primeros Auxilios", "Psicología", "Especialidades ×2"]
+  },
+  {
+    "name": "Soldado",
+    "credit": "9-30",
+    "skillPoints": "EDU × 2 + (DES/FUE × 2)",
+    "skills": ["Armas de Fuego", "Escalar o Natación", "Esquivar", "Furtividad", "Luchar", "Supervivencia", "Reparaciones Mecánicas/Otra Lengua/Primeros Auxilios ×2"]
+  }
+]


### PR DESCRIPTION
## Summary
- add simple character generator page (`creator.html`)
- implement `characterCreator.js` module for rolling stats, choosing occupations and exporting to PDF
- provide example occupations in `occupations.json`
- document new generator in README

## Testing
- `node --check characterCreator.js`
- `node --check scripts.js`
- `python3 -m json.tool occupations.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6856f5f4aaa883209c1a8411f4625d86