### PR TITLE
Add extended character fields

### DIFF
--- a/characterCreator.js
+++ b/characterCreator.js
@@ -6,6 +6,11 @@ export class CharacterCreator {
                 INT: 0, POD: 0, EDU: 0, SUE: 0
             },
             derived: { HP: 0, SAN: 0, MP: 0 },
+            luck: 0,
+            combat: { skills: {}, notes: '' },
+            background: '',
+            equipment: '',
+            possessions: '',
             occupation: null,
             skills: {}
         };
@@ -88,8 +93,19 @@ export class CharacterCreator {
         this.updateDerivedUI();
     }
 
+    rollLuck() {
+        const value = this.rollDice(3, 6) * 5;
+        this.character.luck = value;
+        this.character.stats.SUE = value;
+        const el = document.getElementById('stat-SUE');
+        if (el) el.textContent = value;
+        this.calculateDerived();
+        this.updateDerivedUI();
+    }
+
     rollAll() {
         Object.keys(this.character.stats).forEach(stat => this.rollStat(stat));
+        this.rollLuck();
     }
 
     calculateDerived() {
@@ -137,6 +153,30 @@ export class CharacterCreator {
             this.character.occupation.skills.forEach(sk => { doc.text(`- ${sk}`, 12, y); y+=6; });
         }
         doc.save('personaje.pdf');
+    }
+
+    setCombatSkill(name, value) {
+        this.character.combat.skills[name] = value;
+    }
+
+    setCombatNotes(text) {
+        this.character.combat.notes = text;
+    }
+
+    setBackground(text) {
+        this.character.background = text;
+    }
+
+    setEquipment(text) {
+        this.character.equipment = text;
+    }
+
+    setPossessions(text) {
+        this.character.possessions = text;
+    }
+
+    getCharacter() {
+        return this.character;
     }
 }
 

--- a/wizard.js
+++ b/wizard.js
@@ -15,26 +15,28 @@ function showStep(index){
 }
 
 function gatherData(){
-    creator.character.combatNotes = document.getElementById('combat-notes').value;
-    creator.character.background = document.getElementById('background-notes').value;
-    creator.character.equipment = document.getElementById('equipment-notes').value;
+    creator.setCombatNotes(document.getElementById('combat-notes').value);
+    creator.setBackground(document.getElementById('background-notes').value);
+    creator.setEquipment(document.getElementById('equipment-notes').value);
 }
 
 function renderSummary(){
     gatherData();
+    const char = creator.getCharacter();
     let txt = '';
-    Object.entries(creator.character.stats).forEach(([k,v])=>{txt += `${k}: ${v}\n`;});
-    txt += `PV: ${creator.character.derived.HP}\n`;
-    txt += `Cordura: ${creator.character.derived.SAN}\n`;
-    txt += `PM: ${creator.character.derived.MP}\n`;
-    if(creator.character.occupation){
-        txt += `Ocupación: ${creator.character.occupation.name}\n`;
+    Object.entries(char.stats).forEach(([k,v])=>{txt += `${k}: ${v}\n`;});
+    txt += `PV: ${char.derived.HP}\n`;
+    txt += `Cordura: ${char.derived.SAN}\n`;
+    txt += `PM: ${char.derived.MP}\n`;
+    txt += `Suerte: ${char.luck}\n`;
+    if(char.occupation){
+        txt += `Ocupación: ${char.occupation.name}\n`;
         txt += 'Habilidades:\n';
-        creator.character.occupation.skills.forEach(sk=>{txt+=`- ${sk}\n`;});
+        char.occupation.skills.forEach(sk=>{txt+=`- ${sk}\n`;});
     }
-    if(creator.character.combatNotes){ txt+=`\nCombate:\n${creator.character.combatNotes}\n`; }
-    if(creator.character.background){ txt+=`\nBackground:\n${creator.character.background}\n`; }
-    if(creator.character.equipment){ txt+=`\nEquipamiento:\n${creator.character.equipment}\n`; }
+    if(char.combat.notes){ txt+=`\nCombate:\n${char.combat.notes}\n`; }
+    if(char.background){ txt+=`\nBackground:\n${char.background}\n`; }
+    if(char.equipment){ txt+=`\nEquipamiento:\n${char.equipment}\n`; }
     document.getElementById('summary').textContent = txt;
 }
 


### PR DESCRIPTION
## Summary
- expand CharacterCreator storage with luck, combat, background and gear fields
- add new methods for rolling luck and updating notes
- use new getters and setters in wizard flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856f82ea7d48320b121e3bdf37e6ea6