### PR TITLE
Add manual skill selection

### DIFF
--- a/creator.html
+++ b/creator.html
@@ -28,7 +28,20 @@
         <section>
             <h2 class="section-title">Ocupación</h2>
             <select id="occupation-select"></select>
-            <ul id="skills-list"></ul>
+        </section>
+
+        <section>
+            <h2 class="section-title">Habilidades</h2>
+            <div style="display:flex;gap:20px;flex-wrap:wrap;">
+                <div>
+                    <h3>Ocupación</h3>
+                    <div id="profession-skills"></div>
+                </div>
+                <div>
+                    <h3>Intereses</h3>
+                    <div id="other-skills"></div>
+                </div>
+            </div>
         </section>
         <button class="dice-button" id="export-btn">Exportar a PDF</button>
     </div>

--- a/habilidades.txt
+++ b/habilidades.txt
@@ -1,0 +1,44 @@
+Antropología
+Armas de Fuego
+Arqueología
+Arte y Artesanía
+Buscar Libros
+Cerrajería
+Charlatanería
+Ciencia
+Ciencias Ocultas
+Combatir
+Conducir Automóvil
+Conducir Maquinaria
+Crédito
+Derecho
+Descubrir
+Disfrazarse
+Electricidad
+Encanto
+Equitación
+Escuchar
+Esquivar
+Historia
+Intimidar
+Juego de Manos
+Lanzar
+Lengua Propia
+Mecánica
+Medicina
+Mitos de Cthulhu
+Nadar
+Naturaleza
+Orientarse
+Otras Lenguas
+Persuasión
+Pilotar
+Primeros Auxilios
+Psicoanálisis
+Psicología
+Saltar
+Seguir Rastros
+Sigilo
+Supervivencia
+Tasación
+Trepar

--- a/profesiones.txt
+++ b/profesiones.txt
@@ -1,0 +1,5 @@
+Abogado: Contabilidad, Derecho, Psicología, Usar Bibliotecas, Interpersonal ×2, Otras ×2
+Artista: Arte/Oficio, Encontrar, Historia o Mundo Natural, Otra Lengua, Psicología, Interpersonal, Otras ×2
+Investigador de Policía: Arte/Oficio (Actuar) o Disfraz, Armas de Fuego, Derecho, Escuchar, Psicología, Encontrar, Interpersonal, Otra
+Médico: Ciencia (Biología), Ciencia (Farmacia), Medicina, Otra Lengua (Latín), Primeros Auxilios, Psicología, Especialidades ×2
+Soldado: Armas de Fuego, Escalar o Natación, Esquivar, Furtividad, Luchar, Supervivencia, Reparaciones Mecánicas/Otra Lengua/Primeros Auxilios ×2


### PR DESCRIPTION
## Summary
- list all occupation and personal skills in separate sections
- parse profession and skill data from text files
- export selected skills to PDF
- store new datasets in `habilidades.txt` and `profesiones.txt`

## Testing
- `node --check characterCreator.js`


------
https://chatgpt.com/codex/tasks/task_e_68570c4aaea48320a2864feb721c36de